### PR TITLE
Update to py3

### DIFF
--- a/lxgettext/lpo2json.py
+++ b/lxgettext/lpo2json.py
@@ -44,8 +44,8 @@ def main():
             po_dict[entry.msgid] = entry.msgstr
     if args.output:
         with io.open(args.output, "w", encoding="utf8") as f:
-            data = json.dumps(po_dict, f, ensure_ascii=False)
-            f.write(unicode(data))
+            data = json.dumps(po_dict, ensure_ascii=False)
+            f.write(str(data))
         print(COLOUR_GREEN + "%s: %s empty" % (args.output, len(po) - len(po_dict)) + COLOUR_END)
     else:
         pprint.pprint(po_dict)

--- a/lxgettext/lxgettext.py
+++ b/lxgettext/lxgettext.py
@@ -139,7 +139,7 @@ def update_po(paths, args):
         del po[:]
 
     new_entries = 0
-    for match, occurrences in matches.iteritems():
+    for match, occurrences in matches.items():
 
         # if the string was already listed in the POFile, keep the POEntry in
         # the POFile
@@ -186,7 +186,7 @@ def generate_po(data, filename):
             msgid=msgid,
             occurrence=", ".join("%s:%s" % (filename, i) for i in linenos),
         )
-        for msgid, linenos in matches.iteritems()
+        for msgid, linenos in matches.items()
     )
 
 


### PR DESCRIPTION
Ever since https://github.com/surfly/cobro/pull/7661 this wasn't being installed (it as previously installed via pip2 in dependencies/roles/base/files/requirements_force_update.txt), and thus all `sync_translations` are failing!

Now that we removed py2 completely, I think its best to change this to py3 and install it via pip3

Tested locally on my devbox and `cd cobro && make -j8 -f Makefile.translations` is working correctly